### PR TITLE
version 0.2.9

### DIFF
--- a/examples/client.rb
+++ b/examples/client.rb
@@ -1,10 +1,8 @@
 require_relative '../lib/grenache-ruby-http.rb'
 
-Grenache::Http.configure do |conf|
-   conf.grape_address = "http://127.0.0.1:40002/"
-end
 
-c = Grenache::Http.new
+c = Grenache::Http.new grape_address: "http://127.0.0.1:40002/"
+
 start_time = Time.now
 
 10.times do |n|

--- a/examples/worker.rb
+++ b/examples/worker.rb
@@ -1,15 +1,17 @@
 require_relative '../lib/grenache-ruby-http.rb'
 
-Grenache::Http.configure do |conf|
-   conf.grape_address = "http://127.0.0.1:40002/"
-end
+# This is another way to set a configuration:
+#
+# Grenache::Http.configure do |conf|
+#   conf.grape_address = "http://127.0.0.1:40002/"
+# end
 
 EM.run do
 
   Signal.trap("INT")  { EventMachine.stop }
   Signal.trap("TERM") { EventMachine.stop }
 
-  c = Grenache::Http.new
+  c = Grenache::Http.new grape_address: "http://127.0.0.1:40002/"
 
   c.listen('rpc_test', 5004) do |msg|
     #[StandardError.new("Error!"),"hello #{msg.payload}"]

--- a/grenache-ruby-http.gemspec
+++ b/grenache-ruby-http.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "eventmachine", "~> 1.2"
   spec.add_runtime_dependency "faye-websocket", "~> 0.10"
-  spec.add_runtime_dependency "grenache-ruby-base", "~> 0.2.7"
+  spec.add_runtime_dependency "grenache-ruby-base", "~> 0.2.9"
   spec.add_runtime_dependency "httparty", "~> 0.14.0"
   spec.add_runtime_dependency "oj", "~> 2.18"
   spec.add_runtime_dependency "thin", "~> 1.7"

--- a/lib/grenache/http.rb
+++ b/lib/grenache/http.rb
@@ -39,7 +39,7 @@ module Grenache
 
     def request(key, payload, params={})
       services = lookup(key)
-      if services.size > 0
+      if services && services.size > 0
         json = ServiceMessage.new(payload,key).to_json
         service = get_random_service services
         resp = http_client.request service, json, params

--- a/lib/grenache/http/version.rb
+++ b/lib/grenache/http/version.rb
@@ -1,5 +1,5 @@
 module Grenache
   module HTTP
-    VERSION = "0.2.8"
+    VERSION = "0.2.9"
   end
 end


### PR DESCRIPTION
- fix error when `services` is `nil`
- depend on `grenache-ruby-base` version `0.2.9`