### PR TITLE
add thin configuration parameters

### DIFF
--- a/lib/grenache/http.rb
+++ b/lib/grenache/http.rb
@@ -5,6 +5,10 @@ module Grenache
       conf.thin_threaded = true
       conf.threadpool_size = 10
       conf.verify_mode = Grenache::SSL_VERIFY_PEER
+      conf.thin_timeout = 30
+      conf.thin_max_conns = 1024
+      conf.thin_max_persistent_conns = 512
+      conf.thin_no_epoll = false
     end
 
     def listen(key, port,  opts={}, &block)
@@ -30,6 +34,12 @@ module Grenache
           server.threaded = true
           server.threadpool_size = config.thin_threadpool_size
         end
+
+        # Configure thin
+        server.timeout = config.thin_timeout
+        server.maximum_connections = config.thin_max_conns
+        server.maximum_persistent_connections = config.thin_max_persistent_conns
+        server.no_epoll = config.thin_no_epoll
 
         if tls?
           server.ssl = true

--- a/lib/grenache/http/version.rb
+++ b/lib/grenache/http/version.rb
@@ -1,5 +1,5 @@
 module Grenache
   module HTTP
-    VERSION = "0.2.14"
+    VERSION = "0.2.15"
   end
 end


### PR DESCRIPTION
Add thin configuration parameters:

- *thin_timeout*,  default: 30
- *thin_max_conns*, default: 1024
- *thin_max_persistent_conns*, default: 512
- *thin_no_epoll*, default: false
