### PR TITLE
bump httparty

### DIFF
--- a/grenache-ruby-http.gemspec
+++ b/grenache-ruby-http.gemspec
@@ -16,10 +16,12 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version     = '>= 2.7.0'
+
   spec.add_runtime_dependency "eventmachine", "~> 1.2"
   spec.add_runtime_dependency "faye-websocket", "~> 0.10"
   spec.add_runtime_dependency "grenache-ruby-base", "~> 0.2.18"
-  spec.add_runtime_dependency "httparty", "~> 0.16"
+  spec.add_runtime_dependency "httparty", "~> 0.22.0"
   spec.add_runtime_dependency "oj", "~> 3.6"
   spec.add_runtime_dependency "thin", "~> 1.7"
 

--- a/grenache-ruby-http.gemspec
+++ b/grenache-ruby-http.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version     = '>= 2.7.0'
-
   spec.add_runtime_dependency "eventmachine", "~> 1.2"
   spec.add_runtime_dependency "faye-websocket", "~> 0.10"
   spec.add_runtime_dependency "grenache-ruby-base", "~> 0.2.18"

--- a/lib/grenache/http/version.rb
+++ b/lib/grenache/http/version.rb
@@ -1,5 +1,5 @@
 module Grenache
   module HTTP
-    VERSION = '0.2.21'
+    VERSION = '0.2.22'
   end
 end


### PR DESCRIPTION
fixes audit issue

Name: httparty
Version: 0.18.1
CVE: https://github.com/advisories/GHSA-5pq7-52mg-hr42
GHSA: https://github.com/advisories/GHSA-5pq7-52mg-hr42
Criticality: Medium
URL: [GHSA-5pq7-52mg-hr42](https://github.com/jnunemaker/httparty/security/advisories/GHSA-5pq7-52mg-hr42)
Title: httparty has multipart/form-data request tampering vulnerability
Solution: upgrade to '>= 0.21.0'

Vulnerabilities found!